### PR TITLE
Enable file uploading

### DIFF
--- a/app/src/main/java/org/sil/languageforgeweb/FullscreenActivity.java
+++ b/app/src/main/java/org/sil/languageforgeweb/FullscreenActivity.java
@@ -1,15 +1,21 @@
 package org.sil.languageforgeweb;
 
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.View;
+import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
+import android.widget.Toast;
 
 /**
  * An example full-screen activity that shows and hides the system UI (i.e.
@@ -18,6 +24,22 @@ import android.widget.ProgressBar;
 public class FullscreenActivity extends AppCompatActivity {
     private View mContentView;
     private View mProgressBar;
+
+    private WebView view;
+
+    private static final int FILECHOOSER_RESULTCODE = 1;
+    public static final int REQUEST_SELECT_FILE = 100;
+    public ValueCallback<Uri[]> uploadMultipleCallback;
+    public ValueCallback<Uri> uploadSingleCallback;
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if(resultCode == RESULT_CANCELED) uploadMultipleCallback.onReceiveValue(null);
+        else if(requestCode == REQUEST_SELECT_FILE && resultCode == RESULT_OK) {
+            uploadMultipleCallback.onReceiveValue(new Uri[] {Uri.parse(data.getDataString())});
+        }
+        uploadMultipleCallback = null;
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -28,7 +50,7 @@ public class FullscreenActivity extends AppCompatActivity {
         mProgressBar = findViewById(R.id.progressBar);
         mProgressBar.setVisibility(View.VISIBLE);
 
-        WebView view = (WebView) mContentView;
+        view = (WebView) mContentView;
 
         // Setup Progress Indicator
         ProgressBar mProgress = (ProgressBar) mProgressBar;
@@ -39,6 +61,53 @@ public class FullscreenActivity extends AppCompatActivity {
                 if(progress == 100) {
                     mProgressBar.setVisibility(View.INVISIBLE);
                 }
+            }
+
+            public void openFileChooser(ValueCallback uploadMsg, String acceptType) {
+                uploadSingleCallback = uploadMsg;
+                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
+                intent.setType("*/*");
+                startActivityForResult(Intent.createChooser(intent, "File Browser"), FILECHOOSER_RESULTCODE);
+            }
+
+            //For Android 4.1+ only
+            protected void openFileChooser(ValueCallback<Uri> uploadMsg, String acceptType, String capture) {
+                uploadSingleCallback = uploadMsg;
+                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
+                intent.setType("*/*");
+                startActivityForResult(Intent.createChooser(intent, "File Browser"), FILECHOOSER_RESULTCODE);
+            }
+
+            protected void openFileChooser(ValueCallback<Uri> uploadMsg) {
+                uploadSingleCallback = uploadMsg;
+                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
+                intent.setType("*/*");
+                startActivityForResult(Intent.createChooser(intent, "File Chooser"), FILECHOOSER_RESULTCODE);
+            }
+
+            // For Lollipop 5.0+ Devices
+            public boolean onShowFileChooser(WebView mWebView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams) {
+                if (uploadMultipleCallback != null) {
+                    uploadMultipleCallback.onReceiveValue(null);
+                    uploadMultipleCallback = null;
+                }
+
+                uploadMultipleCallback = filePathCallback;
+                Intent intent = null;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    intent = fileChooserParams.createIntent();
+                }
+                try {
+                    startActivityForResult(intent, REQUEST_SELECT_FILE);
+                } catch (ActivityNotFoundException e) {
+                    uploadMultipleCallback = null;
+                    Toast.makeText(getApplicationContext(), "Cannot Open File Chooser", Toast.LENGTH_LONG).show();
+                    return false;
+                }
+                return true;
             }
         });
         view.setWebViewClient(new WebViewClient());


### PR DESCRIPTION
Sorry this has been slow in coming. I ran into too many issues with the [https://github.com/delight-im/Android-AdvancedWebView](Android-AdvancedWebView) and ended up opting to use the plain Android WebView. I've tested this on my physical device (Android 6.0) and the emulator (8.x, 5.1). Because things changed in Android 5.0, no test is complete without testing 4.x as well. I still have yet to do so. I've just downloaded the 4.1 image and plan to do it very soon.

File upload will not work in 4.4.x, and there appears to be [nothing we can do about it](https://github.com/delight-im/Android-AdvancedWebView/issues/4) other than detect the situation and tell users to use the web browser rather than the app (this has not been implemented). Unfortunately [4.4 KitKat still has about 13.4% of Android's market share](https://developer.android.com/about/dashboards/index.html), and I would imagine it is *much* higher for our target demographics. I think this would be a good use of Google Analytics. We may want to distinguish between use of the app and use of the web browser, since we care more about Android version if they're using the app, and more about browser version if they're using the browser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/android-web-languageforge/1)
<!-- Reviewable:end -->
