### PR TITLE
Enable localStorage and inspecting of webview

### DIFF
--- a/app/src/main/java/org/sil/languageforgeweb/FullscreenActivity.java
+++ b/app/src/main/java/org/sil/languageforgeweb/FullscreenActivity.java
@@ -125,6 +125,10 @@ public class FullscreenActivity extends AppCompatActivity {
 
         view.getSettings().setJavaScriptEnabled(true);
         view.getSettings().setAppCacheEnabled(true);
+        view.getSettings().setDomStorageEnabled(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            view.setWebContentsDebuggingEnabled(true);
+        }
 
     }
 


### PR DESCRIPTION
This should fix the issue where `window.localStorage` being null is causing errors to be reported by Bugsnag. Additionally it enables the webview to be inspected by Chrome for debugging purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/android-web-languageforge/2)
<!-- Reviewable:end -->
